### PR TITLE
GetPreviousSceneでIsWakeupのシーンがスキップされてしまっているのでその対処となります

### DIFF
--- a/Program/Runtime/Service/GameFacilitator/GameFacilitatorService.cs
+++ b/Program/Runtime/Service/GameFacilitator/GameFacilitatorService.cs
@@ -716,9 +716,8 @@ namespace IceMilkTea.Service
                     // さらにここから動作可能なシーンを割り出す
                     for (i = i - 1; i >= 0; --i)
                     {
-                        // もしシーンの状態が Ready か Running か Sleep なら
-                        var state = sceneContextList[i].State;
-                        if (sceneContextList[i].IsReady || sceneContextList[i].IsRunning || sceneContextList[i].IsSleep)
+                        // シーンの状態がまだ生きているなら
+                        if (!sceneContextList[i].IsDestroy)
                         {
                             // このシーンを返す
                             return sceneContextList[i].Scene;


### PR DESCRIPTION
RequestWakeUpSceneを使用するようにした際、以下の手順で呼び出すと意図しないシーンがGetPreviousSceneで取得できてしまいました。

1.ChangeScene(A)
2.ChangeScene(B)
3.ChangeScene(C)
4.RequestWakeUpScene(B)
5.GetPreviousScene(C) → Aが返却される（期待値はB）

どうやらIsWakeup状態のシーンが生きていない判定とされているようですので、
GetPreviousSceneの中で生きているシーンを取得する処理の際にIsWakeup状態のシーンも含まれるようにしました。
単純にor条件に追加しても良かったのですが、シーン状態の定義を見ますとIsDestroyの否定にした方が良さそうでしたので、そのようにしてあります。

マージの検討とご対応のほどよろしくお願いします。