### PR TITLE
従来の実装も維持するための対応

### DIFF
--- a/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
+++ b/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
@@ -44,12 +44,13 @@ namespace IceMilkTea.Core
 
 
 
-    #region 標準ステートマシン実装
+    #region 標準ステートマシン基底実装
     /// <summary>
     /// コンテキストを持つことのできるステートマシンクラスです
     /// </summary>
     /// <typeparam name="TContext">このステートマシンが持つコンテキストの型</typeparam>
-    public class ImtStateMachine<TContext, E>
+    /// <typeparam name="TEvent">ステートマシンへ送信するイベントの型</typeparam>
+    public class ImtStateMachineEx<TContext, TEvent>
     {
         #region ステートクラス本体と特別ステートクラスの定義
         /// <summary>
@@ -58,15 +59,15 @@ namespace IceMilkTea.Core
         public abstract class State
         {
             // メンバ変数定義
-            internal Dictionary<E, State> transitionTable;
-            internal ImtStateMachine<TContext, E> stateMachine;
+            internal Dictionary<TEvent, State> transitionTable;
+            internal ImtStateMachineEx<TContext, TEvent> stateMachine;
 
 
 
             /// <summary>
             /// このステートが所属するステートマシン
             /// </summary>
-            protected ImtStateMachine<TContext, E> StateMachine => stateMachine;
+            protected ImtStateMachineEx<TContext, TEvent> StateMachine => stateMachine;
 
 
             /// <summary>
@@ -122,7 +123,7 @@ namespace IceMilkTea.Core
             /// </summary>
             /// <param name="eventId">渡されたイベントID</param>
             /// <returns>イベントの受付をガードする場合は true を、ガードせずイベントを受け付ける場合は false を返します</returns>
-            protected internal virtual bool GuardEvent(E eventId)
+            protected internal virtual bool GuardEvent(TEvent eventId)
             {
                 // 通常はガードしない
                 return false;
@@ -252,16 +253,16 @@ namespace IceMilkTea.Core
         /// <summary>
         /// このステートマシンが最後に受け付けたイベントID
         /// </summary>
-        public E LastAcceptedEventID { get; private set; }
+        public TEvent LastAcceptedEventID { get; private set; }
 
 
 
         /// <summary>
-        /// ImtStateMachine のインスタンスを初期化します
+        /// ImtStateMachineBase のインスタンスを初期化します
         /// </summary>
         /// <param name="context">このステートマシンが持つコンテキスト</param>
         /// <exception cref="ArgumentNullException">context が null です</exception>
-        public ImtStateMachine(TContext context)
+        public ImtStateMachineEx(TContext context)
         {
             // 渡されたコンテキストがnullなら
             if (context == null)
@@ -298,7 +299,7 @@ namespace IceMilkTea.Core
         /// <param name="eventId">遷移する条件となるイベントID</param>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddAnyTransition<TNextState>(E eventId) where TNextState : State, new()
+        public void AddAnyTransition<TNextState>(TEvent eventId) where TNextState : State, new()
         {
             // 単純に遷移元がAnyStateなだけの単純な遷移追加関数を呼ぶ
             AddTransition<AnyState, TNextState>(eventId);
@@ -319,7 +320,7 @@ namespace IceMilkTea.Core
         /// <exception cref="ArgumentException">nextStateType が State を継承したクラスではありません</exception>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddAnyTransition(Type nextStateType, E eventId)
+        public void AddAnyTransition(Type nextStateType, TEvent eventId)
         {
             // 単純に遷移元がAnyStateなだけの単純な遷移追加関数を呼ぶ
             AddTransition(typeof(AnyState), nextStateType, eventId);
@@ -335,7 +336,7 @@ namespace IceMilkTea.Core
         /// <param name="eventId">遷移する条件となるイベントID</param>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddTransition<TPrevState, TNextState>(E eventId) where TPrevState : State, new() where TNextState : State, new()
+        public void AddTransition<TPrevState, TNextState>(TEvent eventId) where TPrevState : State, new() where TNextState : State, new()
         {
             // 型引数を取るバージョンで呼び出す
             AddTransition(typeof(TPrevState), typeof(TNextState), eventId);
@@ -353,7 +354,7 @@ namespace IceMilkTea.Core
         /// <exception cref="ArgumentException">prevStateType または nextStateType が State を継承したクラスではありません</exception>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddTransition(Type prevStateType, Type nextStateType, E eventId)
+        public void AddTransition(Type prevStateType, Type nextStateType, TEvent eventId)
         {
             // ステートマシンが起動してしまっている場合は
             if (Running)
@@ -415,7 +416,7 @@ namespace IceMilkTea.Core
 
 
                 // 型で引数を取るAddTransitionを呼び続ける
-                AddTransition(fromType, toType, (E)eventId);
+                AddTransition(fromType, toType, (TEvent)eventId);
             }
         }
 
@@ -593,7 +594,7 @@ namespace IceMilkTea.Core
         /// <returns>ステートマシンが送信されたイベントを受け付けた場合は true を、イベントを拒否または、イベントの受付ができない場合は false を返します</returns>
         /// <exception cref="InvalidOperationException">ステートマシンは、まだ起動していません</exception>
         /// <exception cref="InvalidOperationException">ステートが Exit 処理中のためイベントを受け付けることが出来ません</exception>
-        public virtual bool SendEvent(E eventId)
+        public virtual bool SendEvent(TEvent eventId)
         {
             // そもそもまだ現在実行中のステートが存在していないなら例外を投げる
             IfNotRunningThrowException();
@@ -882,10 +883,30 @@ namespace IceMilkTea.Core
 
             // 新しいステートに、自身の参照と遷移テーブルのインスタンスの初期化も行って返す
             newState.stateMachine = this;
-            newState.transitionTable = new Dictionary<E, State>();
+            newState.transitionTable = new Dictionary<TEvent, State>();
             return newState;
         }
         #endregion
+    }
+    #endregion
+
+
+
+    #region 旧intイベント型ベースのステートマシン実装
+    /// <summary>
+    /// コンテキストを持つことのできるステートマシンクラスです
+    /// </summary>
+    /// <typeparam name="TContext">このステートマシンが持つコンテキストの型</typeparam>
+    public class ImtStateMachine<TContext> : ImtStateMachineEx<TContext, int>
+    {
+        /// <summary>
+        /// ImtStateMachine のインスタンスを初期化します
+        /// </summary>
+        /// <param name="context">このステートマシンが持つコンテキスト</param>
+        /// <exception cref="ArgumentNullException">context が null です</exception>
+        public ImtStateMachine(TContext context) : base(context)
+        {
+        }
     }
     #endregion
 }

--- a/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
+++ b/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
@@ -50,7 +50,7 @@ namespace IceMilkTea.Core
     /// </summary>
     /// <typeparam name="TContext">このステートマシンが持つコンテキストの型</typeparam>
     /// <typeparam name="TEvent">ステートマシンへ送信するイベントの型</typeparam>
-    public class ImtStateMachineEx<TContext, TEvent>
+    public class ImtStateMachine<TContext, TEvent>
     {
         #region ステートクラス本体と特別ステートクラスの定義
         /// <summary>
@@ -60,14 +60,14 @@ namespace IceMilkTea.Core
         {
             // メンバ変数定義
             internal Dictionary<TEvent, State> transitionTable;
-            internal ImtStateMachineEx<TContext, TEvent> stateMachine;
+            internal ImtStateMachine<TContext, TEvent> stateMachine;
 
 
 
             /// <summary>
             /// このステートが所属するステートマシン
             /// </summary>
-            protected ImtStateMachineEx<TContext, TEvent> StateMachine => stateMachine;
+            protected ImtStateMachine<TContext, TEvent> StateMachine => stateMachine;
 
 
             /// <summary>
@@ -262,7 +262,7 @@ namespace IceMilkTea.Core
         /// </summary>
         /// <param name="context">このステートマシンが持つコンテキスト</param>
         /// <exception cref="ArgumentNullException">context が null です</exception>
-        public ImtStateMachineEx(TContext context)
+        public ImtStateMachine(TContext context)
         {
             // 渡されたコンテキストがnullなら
             if (context == null)
@@ -897,7 +897,7 @@ namespace IceMilkTea.Core
     /// コンテキストを持つことのできるステートマシンクラスです
     /// </summary>
     /// <typeparam name="TContext">このステートマシンが持つコンテキストの型</typeparam>
-    public class ImtStateMachine<TContext> : ImtStateMachineEx<TContext, int>
+    public class ImtStateMachine<TContext> : ImtStateMachine<TContext, int>
     {
         /// <summary>
         /// ImtStateMachine のインスタンスを初期化します

--- a/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
+++ b/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
@@ -49,7 +49,7 @@ namespace IceMilkTea.Core
     /// コンテキストを持つことのできるステートマシンクラスです
     /// </summary>
     /// <typeparam name="TContext">このステートマシンが持つコンテキストの型</typeparam>
-    public class ImtStateMachine<TContext>
+    public class ImtStateMachine<TContext, E>
     {
         #region ステートクラス本体と特別ステートクラスの定義
         /// <summary>
@@ -58,15 +58,15 @@ namespace IceMilkTea.Core
         public abstract class State
         {
             // メンバ変数定義
-            internal Dictionary<int, State> transitionTable;
-            internal ImtStateMachine<TContext> stateMachine;
+            internal Dictionary<E, State> transitionTable;
+            internal ImtStateMachine<TContext, E> stateMachine;
 
 
 
             /// <summary>
             /// このステートが所属するステートマシン
             /// </summary>
-            protected ImtStateMachine<TContext> StateMachine => stateMachine;
+            protected ImtStateMachine<TContext, E> StateMachine => stateMachine;
 
 
             /// <summary>
@@ -122,7 +122,7 @@ namespace IceMilkTea.Core
             /// </summary>
             /// <param name="eventId">渡されたイベントID</param>
             /// <returns>イベントの受付をガードする場合は true を、ガードせずイベントを受け付ける場合は false を返します</returns>
-            protected internal virtual bool GuardEvent(int eventId)
+            protected internal virtual bool GuardEvent(E eventId)
             {
                 // 通常はガードしない
                 return false;
@@ -252,7 +252,7 @@ namespace IceMilkTea.Core
         /// <summary>
         /// このステートマシンが最後に受け付けたイベントID
         /// </summary>
-        public int LastAcceptedEventID { get; private set; }
+        public E LastAcceptedEventID { get; private set; }
 
 
 
@@ -298,7 +298,7 @@ namespace IceMilkTea.Core
         /// <param name="eventId">遷移する条件となるイベントID</param>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddAnyTransition<TNextState>(int eventId) where TNextState : State, new()
+        public void AddAnyTransition<TNextState>(E eventId) where TNextState : State, new()
         {
             // 単純に遷移元がAnyStateなだけの単純な遷移追加関数を呼ぶ
             AddTransition<AnyState, TNextState>(eventId);
@@ -319,7 +319,7 @@ namespace IceMilkTea.Core
         /// <exception cref="ArgumentException">nextStateType が State を継承したクラスではありません</exception>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddAnyTransition(Type nextStateType, int eventId)
+        public void AddAnyTransition(Type nextStateType, E eventId)
         {
             // 単純に遷移元がAnyStateなだけの単純な遷移追加関数を呼ぶ
             AddTransition(typeof(AnyState), nextStateType, eventId);
@@ -335,7 +335,7 @@ namespace IceMilkTea.Core
         /// <param name="eventId">遷移する条件となるイベントID</param>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddTransition<TPrevState, TNextState>(int eventId) where TPrevState : State, new() where TNextState : State, new()
+        public void AddTransition<TPrevState, TNextState>(E eventId) where TPrevState : State, new() where TNextState : State, new()
         {
             // 型引数を取るバージョンで呼び出す
             AddTransition(typeof(TPrevState), typeof(TNextState), eventId);
@@ -353,7 +353,7 @@ namespace IceMilkTea.Core
         /// <exception cref="ArgumentException">prevStateType または nextStateType が State を継承したクラスではありません</exception>
         /// <exception cref="ArgumentException">既に同じ eventId が設定された遷移先ステートが存在します</exception>
         /// <exception cref="InvalidOperationException">ステートマシンは、既に起動中です</exception>
-        public void AddTransition(Type prevStateType, Type nextStateType, int eventId)
+        public void AddTransition(Type prevStateType, Type nextStateType, E eventId)
         {
             // ステートマシンが起動してしまっている場合は
             if (Running)
@@ -415,7 +415,7 @@ namespace IceMilkTea.Core
 
 
                 // 型で引数を取るAddTransitionを呼び続ける
-                AddTransition(fromType, toType, (int)eventId);
+                AddTransition(fromType, toType, (E)eventId);
             }
         }
 
@@ -593,7 +593,7 @@ namespace IceMilkTea.Core
         /// <returns>ステートマシンが送信されたイベントを受け付けた場合は true を、イベントを拒否または、イベントの受付ができない場合は false を返します</returns>
         /// <exception cref="InvalidOperationException">ステートマシンは、まだ起動していません</exception>
         /// <exception cref="InvalidOperationException">ステートが Exit 処理中のためイベントを受け付けることが出来ません</exception>
-        public virtual bool SendEvent(int eventId)
+        public virtual bool SendEvent(E eventId)
         {
             // そもそもまだ現在実行中のステートが存在していないなら例外を投げる
             IfNotRunningThrowException();
@@ -882,7 +882,7 @@ namespace IceMilkTea.Core
 
             // 新しいステートに、自身の参照と遷移テーブルのインスタンスの初期化も行って返す
             newState.stateMachine = this;
-            newState.transitionTable = new Dictionary<int, State>();
+            newState.transitionTable = new Dictionary<E, State>();
             return newState;
         }
         #endregion

--- a/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
+++ b/Runtime/Core/UnitCode/PureCsharp/StateMachine.cs
@@ -258,7 +258,7 @@ namespace IceMilkTea.Core
 
 
         /// <summary>
-        /// ImtStateMachineBase のインスタンスを初期化します
+        /// ImtStateMachineEx のインスタンスを初期化します
         /// </summary>
         /// <param name="context">このステートマシンが持つコンテキスト</param>
         /// <exception cref="ArgumentNullException">context が null です</exception>

--- a/Tests/Editor/Core/ImtStateMachineTest.cs
+++ b/Tests/Editor/Core/ImtStateMachineTest.cs
@@ -28,7 +28,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// 各種テスト確認用ステートの基本ステートクラスです
         /// </summary>
-        private abstract class SampleBaseState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private abstract class SampleBaseState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステート開始時のSampleValue値
@@ -140,7 +140,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Exit 時に SendEvent する許されざるステートクラスです
         /// </summary>
-        private class ExitSendEventState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class ExitSendEventState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -157,7 +157,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// このステートに遷移したら直ちに SendEvent を行うステートクラスです
         /// </summary>
-        private class ImmediateTransitionState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class ImmediateTransitionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             // 定数定義
             public const int EventId = 12345;
@@ -199,7 +199,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// このステートに遷移して更新処理された時に SendEvent を行うステートクラスです
         /// </summary>
-        private class UpdateTransitionState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class UpdateTransitionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             // 定数定義
             public const int EvnetId = 123456;
@@ -241,7 +241,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// コンテキストのガード有効値に基づいて、ガード制御を行うステートクラスです
         /// </summary>
-        private class ProGuardState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class ProGuardState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートマシンのイベントをガードします
@@ -272,7 +272,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート開始時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class EnterUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class EnterUpdateCaptureState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの開始処理を行います
@@ -289,7 +289,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート更新時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class UpdateUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class UpdateUpdateCaptureState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの更新処理を行います
@@ -306,7 +306,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート終了時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class ExitUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class ExitUpdateCaptureState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -322,7 +322,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Enter時に sampleValue が 0 の場合は、例外を発生させるステートクラスです。
         /// </summary>
-        private class ForceEnterExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class ForceEnterExceptionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの開始処理を行います
@@ -343,7 +343,7 @@ namespace IceMilkTeaTestStatic.Core
         /// Update時に sampleValue が 0 の場合は、例外を発生させるステートクラスです
         /// また例外モードが CatchStateException の場合は MyEventId の遷移イベントを送出します
         /// </summary>
-        private class ForceUpdateExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class ForceUpdateExceptionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// CatchStateException 時に送出するイベントID
@@ -383,7 +383,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Exit時に sampleValue が 0 の場合は、例外を発生させるステートクラスです
         /// </summary>
-        private class ForceExitExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
+        private class ForceExitExceptionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -423,8 +423,8 @@ namespace IceMilkTeaTestStatic.Core
         public void ConstructorTest()
         {
             // null渡しによるインスタンスの生成は許されていないのでテスト
-            Assert.Throws<ArgumentNullException>(() => new ImtStateMachine<ImtStateMachineTest, int>(null));
-            Assert.DoesNotThrow(() => new ImtStateMachine<ImtStateMachineTest, int>(this));
+            Assert.Throws<ArgumentNullException>(() => new ImtStateMachineEx<ImtStateMachineTest, int>(null));
+            Assert.DoesNotThrow(() => new ImtStateMachineEx<ImtStateMachineTest, int>(this));
         }
 
 
@@ -435,7 +435,7 @@ namespace IceMilkTeaTestStatic.Core
         public void StateTransitionTableBuildTest()
         {
             // ステートマシンのインスタンスを生成する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
 
 
             // イベントIDの重複しないステート遷移なら問題ない事を確認する
@@ -488,7 +488,7 @@ namespace IceMilkTeaTestStatic.Core
         public void SendEventTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.AddTransition<SampleBState, ExitSendEventState>(2);
@@ -541,7 +541,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.AddTransition<SampleCState, ImmediateTransitionState>(1);
@@ -620,7 +620,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, ProGuardState>(1);
             stateMachine.AddTransition<SampleBState, ProGuardState>(1);
             stateMachine.AddTransition<ProGuardState, SampleAState>(1);
@@ -681,7 +681,7 @@ namespace IceMilkTeaTestStatic.Core
         public void CurrentStateCheckTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.SetStartState<SampleAState>();
@@ -713,7 +713,7 @@ namespace IceMilkTeaTestStatic.Core
         public void StateStackTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleCState>(1);
             stateMachine.SetStartState<SampleAState>();
@@ -842,7 +842,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<EnterUpdateCaptureState, UpdateUpdateCaptureState>(1);
             stateMachine.AddTransition<UpdateUpdateCaptureState, ExitUpdateCaptureState>(1);
             stateMachine.AddTransition<ExitUpdateCaptureState, UpdateUpdateCaptureState>(1);
@@ -983,7 +983,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成して、この救いようのない例外発生しまくり遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<ForceEnterExceptionState, ForceUpdateExceptionState>(1);
             stateMachine.AddTransition<ForceUpdateExceptionState, ForceExitExceptionState>(1);
             stateMachine.AddTransition<ForceUpdateExceptionState, ForceExitExceptionState>(ForceUpdateExceptionState.MyEventId);

--- a/Tests/Editor/Core/ImtStateMachineTest.cs
+++ b/Tests/Editor/Core/ImtStateMachineTest.cs
@@ -28,7 +28,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// 各種テスト確認用ステートの基本ステートクラスです
         /// </summary>
-        private abstract class SampleBaseState : ImtStateMachine<ImtStateMachineTest>.State
+        private abstract class SampleBaseState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステート開始時のSampleValue値
@@ -140,7 +140,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Exit 時に SendEvent する許されざるステートクラスです
         /// </summary>
-        private class ExitSendEventState : ImtStateMachine<ImtStateMachineTest>.State
+        private class ExitSendEventState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -157,7 +157,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// このステートに遷移したら直ちに SendEvent を行うステートクラスです
         /// </summary>
-        private class ImmediateTransitionState : ImtStateMachine<ImtStateMachineTest>.State
+        private class ImmediateTransitionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             // 定数定義
             public const int EventId = 12345;
@@ -199,7 +199,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// このステートに遷移して更新処理された時に SendEvent を行うステートクラスです
         /// </summary>
-        private class UpdateTransitionState : ImtStateMachine<ImtStateMachineTest>.State
+        private class UpdateTransitionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             // 定数定義
             public const int EvnetId = 123456;
@@ -241,7 +241,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// コンテキストのガード有効値に基づいて、ガード制御を行うステートクラスです
         /// </summary>
-        private class ProGuardState : ImtStateMachine<ImtStateMachineTest>.State
+        private class ProGuardState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートマシンのイベントをガードします
@@ -272,7 +272,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート開始時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class EnterUpdateCaptureState : ImtStateMachine<ImtStateMachineTest>.State
+        private class EnterUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの開始処理を行います
@@ -289,7 +289,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート更新時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class UpdateUpdateCaptureState : ImtStateMachine<ImtStateMachineTest>.State
+        private class UpdateUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの更新処理を行います
@@ -306,7 +306,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート終了時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class ExitUpdateCaptureState : ImtStateMachine<ImtStateMachineTest>.State
+        private class ExitUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -322,7 +322,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Enter時に sampleValue が 0 の場合は、例外を発生させるステートクラスです。
         /// </summary>
-        private class ForceEnterExceptionState : ImtStateMachine<ImtStateMachineTest>.State
+        private class ForceEnterExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの開始処理を行います
@@ -343,7 +343,7 @@ namespace IceMilkTeaTestStatic.Core
         /// Update時に sampleValue が 0 の場合は、例外を発生させるステートクラスです
         /// また例外モードが CatchStateException の場合は MyEventId の遷移イベントを送出します
         /// </summary>
-        private class ForceUpdateExceptionState : ImtStateMachine<ImtStateMachineTest>.State
+        private class ForceUpdateExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// CatchStateException 時に送出するイベントID
@@ -383,7 +383,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Exit時に sampleValue が 0 の場合は、例外を発生させるステートクラスです
         /// </summary>
-        private class ForceExitExceptionState : ImtStateMachine<ImtStateMachineTest>.State
+        private class ForceExitExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -423,8 +423,8 @@ namespace IceMilkTeaTestStatic.Core
         public void ConstructorTest()
         {
             // null渡しによるインスタンスの生成は許されていないのでテスト
-            Assert.Throws<ArgumentNullException>(() => new ImtStateMachine<ImtStateMachineTest>(null));
-            Assert.DoesNotThrow(() => new ImtStateMachine<ImtStateMachineTest>(this));
+            Assert.Throws<ArgumentNullException>(() => new ImtStateMachine<ImtStateMachineTest, int>(null));
+            Assert.DoesNotThrow(() => new ImtStateMachine<ImtStateMachineTest, int>(this));
         }
 
 
@@ -435,7 +435,7 @@ namespace IceMilkTeaTestStatic.Core
         public void StateTransitionTableBuildTest()
         {
             // ステートマシンのインスタンスを生成する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
 
 
             // イベントIDの重複しないステート遷移なら問題ない事を確認する
@@ -488,7 +488,7 @@ namespace IceMilkTeaTestStatic.Core
         public void SendEventTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.AddTransition<SampleBState, ExitSendEventState>(2);
@@ -541,7 +541,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.AddTransition<SampleCState, ImmediateTransitionState>(1);
@@ -620,7 +620,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, ProGuardState>(1);
             stateMachine.AddTransition<SampleBState, ProGuardState>(1);
             stateMachine.AddTransition<ProGuardState, SampleAState>(1);
@@ -681,7 +681,7 @@ namespace IceMilkTeaTestStatic.Core
         public void CurrentStateCheckTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.SetStartState<SampleAState>();
@@ -713,7 +713,7 @@ namespace IceMilkTeaTestStatic.Core
         public void StateStackTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleCState>(1);
             stateMachine.SetStartState<SampleAState>();
@@ -842,7 +842,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<EnterUpdateCaptureState, UpdateUpdateCaptureState>(1);
             stateMachine.AddTransition<UpdateUpdateCaptureState, ExitUpdateCaptureState>(1);
             stateMachine.AddTransition<ExitUpdateCaptureState, UpdateUpdateCaptureState>(1);
@@ -983,7 +983,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成して、この救いようのない例外発生しまくり遷移テーブルを構築する
-            var stateMachine = new ImtStateMachine<ImtStateMachineTest>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<ForceEnterExceptionState, ForceUpdateExceptionState>(1);
             stateMachine.AddTransition<ForceUpdateExceptionState, ForceExitExceptionState>(1);
             stateMachine.AddTransition<ForceUpdateExceptionState, ForceExitExceptionState>(ForceUpdateExceptionState.MyEventId);

--- a/Tests/Editor/Core/ImtStateMachineTest.cs
+++ b/Tests/Editor/Core/ImtStateMachineTest.cs
@@ -28,7 +28,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// 各種テスト確認用ステートの基本ステートクラスです
         /// </summary>
-        private abstract class SampleBaseState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private abstract class SampleBaseState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステート開始時のSampleValue値
@@ -140,7 +140,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Exit 時に SendEvent する許されざるステートクラスです
         /// </summary>
-        private class ExitSendEventState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class ExitSendEventState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -157,7 +157,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// このステートに遷移したら直ちに SendEvent を行うステートクラスです
         /// </summary>
-        private class ImmediateTransitionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class ImmediateTransitionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             // 定数定義
             public const int EventId = 12345;
@@ -199,7 +199,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// このステートに遷移して更新処理された時に SendEvent を行うステートクラスです
         /// </summary>
-        private class UpdateTransitionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class UpdateTransitionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             // 定数定義
             public const int EvnetId = 123456;
@@ -241,7 +241,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// コンテキストのガード有効値に基づいて、ガード制御を行うステートクラスです
         /// </summary>
-        private class ProGuardState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class ProGuardState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートマシンのイベントをガードします
@@ -272,7 +272,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート開始時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class EnterUpdateCaptureState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class EnterUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの開始処理を行います
@@ -289,7 +289,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート更新時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class UpdateUpdateCaptureState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class UpdateUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの更新処理を行います
@@ -306,7 +306,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// ステート終了時にアップデートプロパティをキャプチャするステートクラスです
         /// </summary>
-        private class ExitUpdateCaptureState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class ExitUpdateCaptureState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -322,7 +322,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Enter時に sampleValue が 0 の場合は、例外を発生させるステートクラスです。
         /// </summary>
-        private class ForceEnterExceptionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class ForceEnterExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの開始処理を行います
@@ -343,7 +343,7 @@ namespace IceMilkTeaTestStatic.Core
         /// Update時に sampleValue が 0 の場合は、例外を発生させるステートクラスです
         /// また例外モードが CatchStateException の場合は MyEventId の遷移イベントを送出します
         /// </summary>
-        private class ForceUpdateExceptionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class ForceUpdateExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// CatchStateException 時に送出するイベントID
@@ -383,7 +383,7 @@ namespace IceMilkTeaTestStatic.Core
         /// <summary>
         /// Exit時に sampleValue が 0 の場合は、例外を発生させるステートクラスです
         /// </summary>
-        private class ForceExitExceptionState : ImtStateMachineEx<ImtStateMachineTest, int>.State
+        private class ForceExitExceptionState : ImtStateMachine<ImtStateMachineTest, int>.State
         {
             /// <summary>
             /// ステートの終了処理を行います
@@ -423,8 +423,8 @@ namespace IceMilkTeaTestStatic.Core
         public void ConstructorTest()
         {
             // null渡しによるインスタンスの生成は許されていないのでテスト
-            Assert.Throws<ArgumentNullException>(() => new ImtStateMachineEx<ImtStateMachineTest, int>(null));
-            Assert.DoesNotThrow(() => new ImtStateMachineEx<ImtStateMachineTest, int>(this));
+            Assert.Throws<ArgumentNullException>(() => new ImtStateMachine<ImtStateMachineTest, int>(null));
+            Assert.DoesNotThrow(() => new ImtStateMachine<ImtStateMachineTest, int>(this));
         }
 
 
@@ -435,7 +435,7 @@ namespace IceMilkTeaTestStatic.Core
         public void StateTransitionTableBuildTest()
         {
             // ステートマシンのインスタンスを生成する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
 
 
             // イベントIDの重複しないステート遷移なら問題ない事を確認する
@@ -488,7 +488,7 @@ namespace IceMilkTeaTestStatic.Core
         public void SendEventTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.AddTransition<SampleBState, ExitSendEventState>(2);
@@ -541,7 +541,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.AddTransition<SampleCState, ImmediateTransitionState>(1);
@@ -620,7 +620,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, ProGuardState>(1);
             stateMachine.AddTransition<SampleBState, ProGuardState>(1);
             stateMachine.AddTransition<ProGuardState, SampleAState>(1);
@@ -681,7 +681,7 @@ namespace IceMilkTeaTestStatic.Core
         public void CurrentStateCheckTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleAState>(1);
             stateMachine.SetStartState<SampleAState>();
@@ -713,7 +713,7 @@ namespace IceMilkTeaTestStatic.Core
         public void StateStackTest()
         {
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<SampleAState, SampleBState>(1);
             stateMachine.AddTransition<SampleBState, SampleCState>(1);
             stateMachine.SetStartState<SampleAState>();
@@ -842,7 +842,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成してサクッと遷移テーブルを構築する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<EnterUpdateCaptureState, UpdateUpdateCaptureState>(1);
             stateMachine.AddTransition<UpdateUpdateCaptureState, ExitUpdateCaptureState>(1);
             stateMachine.AddTransition<ExitUpdateCaptureState, UpdateUpdateCaptureState>(1);
@@ -983,7 +983,7 @@ namespace IceMilkTeaTestStatic.Core
 
 
             // ステートマシンのインスタンスを生成して、この救いようのない例外発生しまくり遷移テーブルを構築する
-            var stateMachine = new ImtStateMachineEx<ImtStateMachineTest, int>(this);
+            var stateMachine = new ImtStateMachine<ImtStateMachineTest, int>(this);
             stateMachine.AddTransition<ForceEnterExceptionState, ForceUpdateExceptionState>(1);
             stateMachine.AddTransition<ForceUpdateExceptionState, ForceExitExceptionState>(1);
             stateMachine.AddTransition<ForceUpdateExceptionState, ForceExitExceptionState>(ForceUpdateExceptionState.MyEventId);


### PR DESCRIPTION
従来のImtStateMachine<TContext>型を維持するために、イベント型を指定可能とする
ImtStateMachine<TContext, TEvent>型を継承させた実装も含めています。

ご確認いただければと存じます。